### PR TITLE
Reader closure problem

### DIFF
--- a/vidsz/opencv/reader/base_reader.py
+++ b/vidsz/opencv/reader/base_reader.py
@@ -241,12 +241,12 @@ class Reader(IReader):
         """
         if self._video_stream is not None:
             self._video_stream.release()
-            self._video_stream = None
 
     def __del__(self) -> None:
         """Release Resources
         """
         self.release()
+        self._video_stream = None
 
     def __next__(self) -> np.ndarray:
         """Returns next frame from the video

--- a/vidsz/opencv/writer/base_writer.py
+++ b/vidsz/opencv/writer/base_writer.py
@@ -288,12 +288,12 @@ class Writer(IWriter):
         """
         if self._video_writer is not None:
             self._video_writer.release()
-            self._video_writer = None
 
     def __del__(self) -> None:
         """Release Resources
         """
         self.release()
+        self._video_writer = None
 
     def __repr__(self) -> str:
         """Writer's Info


### PR DESCRIPTION
Fixes #6

A possibly better solution would be differentiating the behaviours of methods `release` and `__del__`.

In the proposed changes, releasing the `vidsz.Reader` coincides with releasing the `cv2.Capture`, after which the object still exists and the method `isOpened()` can be called on it, giving False as a result which seems more appropriate.

Calling instead `__del__()` first releases the input and then sets the Capture to None.

This is true also for `Writer` class and thus I propose the same changes.