### PR TITLE
Remove opencv.reader.read_all method

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ reader.release()
 ```python
 with Reader("static/countdown.mp4") as reader:
     frame = reader.read()
-    frames = reader.read_all() # list of all ndarry-frames returned
 ```
 
 

--- a/test/opencv/test_reader.py
+++ b/test/opencv/test_reader.py
@@ -108,20 +108,6 @@ def test_for_loop(vpath: str) -> None:
 
 
 @pytest.mark.parametrize("vpath", VIDEO_PATHS)
-def test_with_all(vpath: str) -> None:
-    """Test Reader behavior with 'with' block.
-
-    Args:
-        vpath (str): path to video
-    """
-    # or read with a with block
-    with Reader(vpath) as reader:
-        frames = reader.read_all()  # list of frames returned
-
-        assert all(frame is not None for frame in frames), "Bad Frame Read"
-
-
-@pytest.mark.parametrize("vpath", VIDEO_PATHS)
 def test_reader_after_release(vpath: str) -> None:
     """Test Reader behavior after release operation.
 

--- a/test/opencv/test_reader_batching.py
+++ b/test/opencv/test_reader_batching.py
@@ -86,27 +86,3 @@ def test_correctness_dynamic(vpath: str, batch_size: int) -> None:
 
     cv2_reader.release()
     reader.release()
-
-
-@pytest.mark.parametrize("vpath", VIDEO_PATHS)
-@pytest.mark.parametrize("batch_size", BATCH_SIZES)
-def test_batch_read_all(vpath: str, batch_size: int) -> None:
-    """Test Opencv-Reader operability with read_all with batch
-    (dynamic batching)
-
-    Args:
-        vpath (str): path to video
-    """
-    # get expected_shape
-    cv2_reader = cv2.VideoCapture(vpath)
-    width = int(cv2_reader.get(cv2.CAP_PROP_FRAME_WIDTH))
-    height = int(cv2_reader.get(cv2.CAP_PROP_FRAME_HEIGHT))
-    expected_shape = (height, width, 3)
-    cv2_reader.release()
-
-    with Reader(vpath, batch_size=batch_size, dynamic_batch=True) as reader:
-        batches_lst = reader.read_all()
-
-        batch = batches_lst[0]
-        assert len(batch.shape) == 4, "Batch axis count does not match."
-        assert batch.shape[1:] == expected_shape, "Batch Shape doesn't match"

--- a/vidsz/__init__.py
+++ b/vidsz/__init__.py
@@ -38,7 +38,6 @@ Backends
     # or read with a with block
     with Reader("static/countdown.mp4") as reader:
         frame = reader.read()
-        frames = reader.read_all() # list of frames returned
 
 ```
 

--- a/vidsz/interfaces/reader.py
+++ b/vidsz/interfaces/reader.py
@@ -119,15 +119,6 @@ class IReader(metaclass=abc.ABCMeta):
         ...
 
     @abc.abstractmethod
-    def read_all(self) -> List[np.ndarray]:
-        """Read all the frames into a list
-
-        Returns:
-            List[np.ndarray]: List containing all the remaining frames in Video
-        """
-        ...
-
-    @abc.abstractmethod
     def release(self) -> None:
         """Release Resources
         """

--- a/vidsz/opencv/reader/base_reader.py
+++ b/vidsz/opencv/reader/base_reader.py
@@ -227,15 +227,6 @@ class Reader(IReader):
             return self.read_frame()
         return self.read_batch()
 
-    def read_all(self) -> List[np.ndarray]:
-        """Read all the frames into a list.
-        Returns list of batches of frames if batch_size was set.
-
-        Returns:
-            List[np.ndarray]: List containing all the remaining frames in Video
-        """
-        return [frame for frame in self]
-
     def release(self) -> None:
         """Release Resources
         """


### PR DESCRIPTION
This PR removes ```Reader.read_all``` method because of the following issues
- the possibility of memory blowing up
- not very useful after the introduction of batching
- can be confusing ```List[frame]``` vs ```List[batch-of-frames]```
